### PR TITLE
Update runtime, add x-checker-data

### DIFF
--- a/io.github.mhogomchungu.media-downloader.json
+++ b/io.github.mhogomchungu.media-downloader.json
@@ -1,7 +1,7 @@
 {
   "app-id" : "io.github.mhogomchungu.media-downloader",
   "runtime" : "org.kde.Platform",
-  "runtime-version" : "6.7",
+  "runtime-version" : "6.8",
   "sdk" : "org.kde.Sdk",
   "command" : "io.github.mhogomchungu.media-downloader",
   "finish-args" : [
@@ -18,15 +18,18 @@
       "name" : "mutagen",
       "buildsystem" : "simple",
       "build-commands" : [
-        "`pwd`/setup.py build",
-        "`pwd`/setup.py install --prefix /app"
+        "pip3 install --prefix=/app . --no-build-isolation"
       ],
-      "cleanup" : [],
       "sources" : [
         {
-          "type" : "archive",
-          "url" : "https://github.com/quodlibet/mutagen/releases/download/release-1.47.0/mutagen-1.47.0.tar.gz",
-          "sha256" : "719fadef0a978c31b4cf3c956261b3c58b6948b32023078a2117b1de09f0fc99"
+          "type" : "git",
+          "url" : "https://github.com/quodlibet/mutagen.git",
+          "tag" : "release-1.47.0",
+          "commit" : "e38a475b4e00e248e04c50901d75b526464550d3",
+          "x-checker-data" : {
+            "type" : "git",
+            "tag-pattern" : "^release-([\\d.]+)$"
+          }
         }
       ]
     },
@@ -39,24 +42,14 @@
       ],
       "sources" : [
         {
-          "type" : "archive",
-          "url" : "https://github.com/mhogomchungu/media-downloader/releases/download/5.2.0/media-downloader-flatpak.tar.xz",
-          "sha256" : "7f6933b39a79ed68682612eceefb4580f650ea2c24b1d26b0f36d6bc3c650fd9"
-        },
-        {
-          "type" : "file",
-          "url" : "https://raw.githubusercontent.com/mhogomchungu/media-downloader/a186152191cc5bf6259ae5e6d2fc12a9e3c0a0bc/src/flatpak/io.github.mhogomchungu.media-downloader.png",
-          "sha256" : "2e8158f8c46cb6e39c007c9cf6106c12c1bb6b116057bf4a72d048dfbcab4598"
-        },
-        {
-          "type" : "file",
-          "url" : "https://raw.githubusercontent.com/mhogomchungu/media-downloader/c5aafbae90462285bbe23e37d8982067ca388f0a/src/flatpak/io.github.mhogomchungu.media-downloader.metainfo.xml",
-          "sha256" : "b049ffea0f352d62d5b82f890af161ba25e9682425402dc63ecc02bdcfe6f72b"
-        },
-        {
-          "type" : "file",
-          "url" : "https://raw.githubusercontent.com/mhogomchungu/media-downloader/a186152191cc5bf6259ae5e6d2fc12a9e3c0a0bc/src/flatpak/io.github.mhogomchungu.media-downloader.desktop",
-          "sha256" : "ee6793a6ebbeabcd2ba5bb05fd07d3e48d6607374c02b9583e45eaef61555082"
+          "type" : "git",
+          "url" : "https://github.com/mhogomchungu/media-downloader.git",
+          "tag" : "5.2.0",
+          "commit" : "98f48fab733f9d931479d52f2625965eae1141cf",
+          "x-checker-data" : {
+            "type" : "git",
+            "tag-pattern" : "^([\\d.]+)$"
+          }
         }
       ]
     }


### PR DESCRIPTION
Switches to git sources for easy use of flatpak-external-data checker in case of media-downloader

mutagen: `setup.py` is deprecated, uses `pip3 install .` instead

media-downloader: additional files are included and installed with the main source, no need to download them