### PR TITLE
Update io.github.mhogomchungu.media-downloader.json

### DIFF
--- a/io.github.mhogomchungu.media-downloader.json
+++ b/io.github.mhogomchungu.media-downloader.json
@@ -40,22 +40,6 @@
             ]
         },
         {
-            "name": "quickjs",
-            "buildsystem": "simple",
-            "build-commands": [
-                "make",
-                "strip qjs",
-                "cp qjs /app/bin"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://bellard.org/quickjs/quickjs-2025-09-13-2.tar.xz",
-                    "sha256": "996c6b5018fc955ad4d06426d0e9cb713685a00c825aa5c0418bd53f7df8b0b4"
-                }
-            ]
-        },
-        {
             "name": "python3-setuptools_rust",
             "buildsystem": "simple",
             "build-commands": [


### PR DESCRIPTION
Remove quickjs build time dependency. This dependency is replaced by quickjs-ng runtime dependency